### PR TITLE
Feature: Add flash dump functions (full and partial)

### DIFF
--- a/include/flash.h
+++ b/include/flash.h
@@ -13,4 +13,11 @@ void flashRead(uint32_t addr, uint8_t* buffer, size_t len);
 // Write 'len' bytes from data to 'addr'
 void flashWrite(uint32_t addr, const uint8_t* data, size_t len);
 
+// Dumps a given range (partial dump)
+void flashDumpRange(uint32_t addr, size_t len);
+
+// Dumps the entire 16 MB flash contents over serial
+// flashDumpAll() is just a wrapper that calls flashDumpRange(0, 16MB)
+void flashDumpAll();
+
 #endif // FLASH_H

--- a/src/flash.cpp
+++ b/src/flash.cpp
@@ -2,7 +2,7 @@
 
 // Chip Select pin
 #define FLASH_CS_PIN PA4
-
+#define FLASH_SIZE_BYTES (16 * 1024 * 1024) // 16 MB total size
 
 
 void flashInit() {
@@ -18,7 +18,6 @@ void flashInit() {
     SPI.setDataMode(SPI_MODE0);           // Mode 0
     SPI.setBitOrder(MSBFIRST);            // Most significant bit first
 }
-
 
 
 void flashRead(uint32_t addr, uint8_t* buffer, size_t len) {
@@ -41,7 +40,6 @@ void flashRead(uint32_t addr, uint8_t* buffer, size_t len) {
     // Pull CS high to deselect flash
     digitalWrite(FLASH_CS_PIN, HIGH);
 }
-
 
 
 // Helper: send Write Enable command
@@ -92,4 +90,28 @@ void flashWrite(uint32_t addr, const uint8_t* data, size_t len) {
         addr += chunk;
         written += chunk;
     }
+}
+
+
+void flashDumpRange(uint32_t addr, size_t len) {
+    const size_t chunkSize = 256;   // read in manageable chunks
+    uint8_t buffer[chunkSize];
+
+    while (len > 0) {
+        size_t toRead = min(chunkSize, len);
+
+        flashRead(addr, buffer, toRead);
+
+        // Print as raw binary (can be piped to file later)
+        for (size_t i = 0; i < toRead; i++) {
+            Serial.write(buffer[i]);
+        }
+
+        addr += toRead;
+        len  -= toRead;
+    }
+}
+
+void flashDumpAll() {
+    flashDumpRange(0, FLASH_SIZE_BYTES);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,14 +6,10 @@
 void setup() {
     // -------------------- Setup --------------------
     pinMode(PD13, OUTPUT);     // status LED
-    Serial.begin(921600);        // initialize serial for debug output
-
-    // TODO Need to mess around with the baud rate to optimise the speed vs reliability
+    Serial.begin(115200);        // initialize serial for debug output
 
     flashInit();               // initialize SPI flash
-
-    // Example: Dump first 1 KB
-    flashDumpRange(0, 1024);
+    
 }
 
 void loop() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,8 +6,14 @@
 void setup() {
     // -------------------- Setup --------------------
     pinMode(PD13, OUTPUT);     // status LED
-    Serial.begin(9600);        // initialize serial for debug output
+    Serial.begin(921600);        // initialize serial for debug output
+
+    // TODO Need to mess around with the baud rate to optimise the speed vs reliability
+
     flashInit();               // initialize SPI flash
+
+    // Example: Dump first 1 KB
+    flashDumpRange(0, 1024);
 }
 
 void loop() {


### PR DESCRIPTION
This pull request adds two new functions to the flash memory module:

flashDumpRange(uint32_t addr, size_t len)
Streams a specified range of the SPI flash to serial as raw binary.
Reads in 256-byte chunks to balance memory usage and performance.

flashDumpAll()
Wrapper that dumps the entire 16 MB SPI flash by calling flashDumpRange(0, 16*1024*1024).

Functions have been stub-tested in main.cpp using a small sample buffer.